### PR TITLE
Lots of bug fixes

### DIFF
--- a/scripts/switch-keys/config-example.py
+++ b/scripts/switch-keys/config-example.py
@@ -37,3 +37,6 @@ path_to_cli_wallet = "/home/user/src/bitshares-2/programs/cli_wallet/cli_wallet"
 path_to_wallet_json = "/home/user/src/bitshares-2/programs/cli_wallet/wallet.json"
 
 
+path_to_price_feed_script = "/home/user/src/python-graphenelib/scripts/pricefeeds/pricefeeds.py"
+
+feed_script_time = 42

--- a/scripts/switch-keys/config-example.py
+++ b/scripts/switch-keys/config-example.py
@@ -37,6 +37,6 @@ path_to_cli_wallet = "/home/user/src/bitshares-2/programs/cli_wallet/cli_wallet"
 path_to_wallet_json = "/home/user/src/bitshares-2/programs/cli_wallet/wallet.json"
 
 
-path_to_price_feed_script = "/home/user/src/python-graphenelib/scripts/pricefeeds/pricefeeds.py"
+path_to_feed_script = "/home/user/src/python-graphenelib/scripts/pricefeeds/pricefeeds.py"
 
 feed_script_time = 42

--- a/scripts/switch-keys/example-config.ini
+++ b/scripts/switch-keys/example-config.ini
@@ -1,0 +1,73 @@
+# Endpoint for P2P node to listen on
+# p2p-endpoint = 
+
+# P2P nodes to connect to on startup (may specify multiple times)
+# seed-node = 
+
+# JSON array of P2P nodes to connect to on startup
+# seed-nodes = 
+
+# Pairs of [BLOCK_NUM,BLOCK_ID] that should be enforced as checkpoints.
+# checkpoint = 
+
+# Endpoint for websocket RPC to listen on
+rpc-endpoint = 127.0.0.1:8090
+
+# Endpoint for TLS websocket RPC to listen on
+# rpc-tls-endpoint = 
+
+# The TLS certificate file for this server
+# server-pem = 
+
+# Password for this certificate
+# server-pem-password = 
+
+# File to read Genesis State from
+# genesis-json = 
+
+# Block signing key to use for init witnesses, overrides genesis file
+# dbg-init-key = 
+
+# JSON file specifying API permissions
+# api-access = 
+
+# Enable block production, even if the chain is stale.
+enable-stale-production = false
+
+# Percent of witnesses (0-99) that must be participating in order to produce blocks
+required-participation = false
+
+# ID of witness controlled by this node (e.g. "1.6.5", quotes are required, may specify multiple times)
+witness-id = "1.6.14"
+
+# Tuple of [PublicKey, WIF private key] (may specify multiple times)
+private-key = ["BTS5gH5wokGkbhcZZpxLEc884xNby3HAkiEo39bMXZ4b2AvNuSWni","5..................................................W"]
+# Account ID to track history for (may specify multiple times)
+# track-account = 
+
+# Track market history by grouping orders into buckets of equal size measured in seconds specified as a JSON array of numbers
+bucket-size = [15,60,300,3600,86400]
+
+# How far back in time to track history for each bucket size, measured in the number of buckets (default: 1000)
+history-per-size = 1000
+
+# declare an appender named "stderr" that writes messages to the console
+[log.console_appender.stderr]
+stream=std_error
+
+# declare an appender named "p2p" that writes messages to p2p.log
+[log.file_appender.p2p]
+filename=logs/p2p/p2p.log
+# filename can be absolute or relative to this config file
+
+# route any messages logged to the default logger to the "stderr" logger we
+# declared above, if they are info level are higher
+[logger.default]
+level=info
+appenders=stderr
+
+# route messages sent to the "p2p" logger to the p2p appender declared above
+[logger.p2p]
+level=debug
+appenders=p2p
+

--- a/scripts/switch-keys/switch.py
+++ b/scripts/switch-keys/switch.py
@@ -110,7 +110,7 @@ def checkTime():
 
 recentmissed = 0
 emergency = False
-replay = 3
+replay = 0
 crash = 0
 lastHour = 0
 closeScreens()

--- a/scripts/switch-keys/switch.py
+++ b/scripts/switch-keys/switch.py
@@ -7,6 +7,7 @@ from grapheneapi import GrapheneWebsocket, GrapheneWebsocketProtocol
 import time
 import config
 import subprocess
+from time import gmtime, strftime
 
 
 rpc = GrapheneWebsocket("localhost", 8092, "", "")
@@ -85,6 +86,26 @@ def resync():
     print("waiting...")
     time.sleep(10)
 
+### testing running feed schedule through script
+#def checkTime(lastHour):
+#    hour = strftime("%H", gmtime())
+#   minute = strftime("%M", gmtime())
+#    hour = int(hour)
+#    minute = int(minute)
+#    if minute % 42 == 0:
+#        if lastHour == 23:
+#            if hour == 0:
+#                subprocess.call(["screen","-S","feed","-p","0","-X","quit"])
+#                subprocess.call(["screen","-dmS","feed","python3",config.path_to_feed_script])
+#                return hour
+#        elif hour > lastHour:
+#            subprocess.call(["screen","-S","feed","-p","0","-X","quit"])
+#            subprocess.call(["screen","-dmS","feed","python3",config.path_to_feed_script])
+#            return hour
+#        else:
+#            return lastHour
+#    else:
+#        return lastHour
 
 closeScreens()
 openScreens()
@@ -97,6 +118,8 @@ witness = rpc.get_witness(config.witnessname)
 lastblock = witness["last_confirmed_block_num"]
 emergency = False
 replay = 0
+crash = 0
+lastHour = 0
 
 while True:
     try:
@@ -149,8 +172,10 @@ while True:
             print(config.witnessname + " missed a block.  total missed = " + str(missed) + " recent missed = " + str(recentmissed))
             lastblock = witness["last_confirmed_block_num"]
         else:
+#            lastHour = checkTime(lastHour)
             waitAndNotify()
             replay = watch(replay)
+### if you are having issue try commenting out the try line and everything below the except line to prevent auto restart
     except:
         if crash > 2:
             crash = watch(crash)

--- a/scripts/switch-keys/switch.py
+++ b/scripts/switch-keys/switch.py
@@ -24,7 +24,7 @@ def closeScreens():
 def openScreens():
     print("opening witness")
     subprocess.call(["screen","-dmS","witness",config.path_to_witness_node,"-d",config.path_to_data_dir,"--replay-blockchain"])
-    print("waiting...")
+    print("waiting..." + "replay = " + str(replay) + "                     crash = " + str(crash))
     time.sleep(180)
     print("opening wallet")
     subprocess.call(["screen","-dmS","wallet",config.path_to_cli_wallet,"-H",config.rpc_port,"-w",config.path_to_wallet_json])
@@ -56,22 +56,27 @@ def waitAndNotify():
     block = info["head_block_num"]
     age = info["head_block_age"]
     participation = info["participation"]
-    print(str(block) + "     " + str(age) + "     " + str(participation))
+    print(str(block) + "     " + str(age) + "     " + str(participation) + "      replay = " + str(replay) + "      crash = " + str(crash))
 
 def watch(num):
-    if num > 2:
-        closeScreens()
-        resysnc()
-        rpc.unlock(config.wallet_password)
-        time.sleep(30)
-        return 0
-    elif float(info()) < 50:
-        closeScreens()
-        openScreens()
-        rpc.unlock(config.wallet_password)
-        time.sleep(30)
-        num =+ 1
-        return num
+    if float(info()) < 50:
+        if num > 2:
+            closeScreens()
+            resysnc()
+            print("unlocking wallet")
+            rpc.unlock(config.wallet_password)
+            print("wallet unlocked")
+            time.sleep(30)
+            return 0
+        else:
+            closeScreens()
+            openScreens()
+            print("unlocking wallet")
+            rpc.unlock(config.wallet_password)
+            print("wallet unlocked")
+            time.sleep(30)
+            num += 1
+            return num
     else:
         return 0
 
@@ -87,39 +92,28 @@ def resync():
     time.sleep(10)
 
 ### testing running feed schedule through script
-#def checkTime(lastHour):
+#def checkTime():
 #    hour = strftime("%H", gmtime())
-#   minute = strftime("%M", gmtime())
+#    minute = strftime("%M", gmtime())
 #    hour = int(hour)
 #    minute = int(minute)
-#    if minute % 42 == 0:
-#        if lastHour == 23:
-#            if hour == 0:
-#                subprocess.call(["screen","-S","feed","-p","0","-X","quit"])
-#                subprocess.call(["screen","-dmS","feed","python3",config.path_to_feed_script])
-#                return hour
-#        elif hour > lastHour:
-#            subprocess.call(["screen","-S","feed","-p","0","-X","quit"])
-#            subprocess.call(["screen","-dmS","feed","python3",config.path_to_feed_script])
-#            return hour
-#        else:
-#            return lastHour
-#    else:
-#        return lastHour
+#    if minute % 60 == config.price_feed_time:
+#        subprocess.call(["screen","-S","feed","-p","0","-X","quit"])
+#        subprocess.call(["screen","-dmS","feed","python3",config.path_to_feed_script])
+#        time.sleep(60)
 
+recentmissed = 0
+emergency = False
+replay = 0
+crash = 0
 closeScreens()
 openScreens()
 print("unlocking wallet")
 rpc.unlock(config.wallet_password)
 
 missed = getMissed(config.witnessname)
-recentmissed = 0
 witness = rpc.get_witness(config.witnessname)
 lastblock = witness["last_confirmed_block_num"]
-emergency = False
-replay = 0
-crash = 0
-lastHour = 0
 
 while True:
     try:
@@ -172,18 +166,62 @@ while True:
             print(config.witnessname + " missed a block.  total missed = " + str(missed) + " recent missed = " + str(recentmissed))
             lastblock = witness["last_confirmed_block_num"]
         else:
-#            lastHour = checkTime(lastHour)
+#            checkTime()
             waitAndNotify()
             replay = watch(replay)
 ### if you are having issue try commenting out the try line and everything below the except line to prevent auto restart
     except:
-        if crash > 2:
-            crash = watch(crash)
-        else:
-            print("error.  restarting.")
-            closeScreens()
-            openScreens()
-            crash =+ 1
-
+        try:
+            if crash > 2:
+                crash = 0
+                closeScreens()
+                resync()
+                print("unlocking wallet")
+                rpc.unlock(config.wallet_password)
+                print("wallet unlocked")
+            else:
+                crash += 1
+                print("error.  restarting.")
+                closeScreens()
+                openScreens()
+                print("unlocking wallet")
+                rpc.unlock(config.wallet_password)
+                print("wallet unlocked")
+        except:
+            try:
+                if crash > 2:
+                    crash = 0
+                    closeScreen()
+                    resync()
+                    print("unlocking wallet")
+                    rpc.unlock(config.wallet_password)
+                else:
+                    crash += 1
+                    print("error... restarting")
+                    closeScreens()
+                    openScreens()
+                    print("unlocking wallet")
+                    rpc.unlock(config.wallet_password)
+            except:
+                try:
+                    if crash > 2:
+                        crash = 0
+                        closeScreens()
+                        resync()
+                        print("unlocking wallet")
+                        rpc.unlock(config.wallet_password)
+                    else:
+                        crash += 1
+                        print("error.  restarting.")
+                        closeScreens()
+                        openScreens()
+                        print("unlocking wallet")
+                        rpc.unlock(config.wallet_password)
+                except:
+                    crash = 0
+                    closeScreens()
+                    resync()
+                    print("unlocking wallet")
+                    rpc.unlock(config.wallet_password)
 
 

--- a/scripts/switch-keys/switch.py
+++ b/scripts/switch-keys/switch.py
@@ -103,7 +103,7 @@ def checkTime():
     minute = int(minute)
     if minute % 60 == config.feed_script_time:
         subprocess.call(["screen","-S","feed","-p","0","-X","quit"])
-        subprocess.call(["screen","-dmS","feed","python3",config.path_to_feed$
+        subprocess.call(["screen","-dmS","feed","python3",config.path_to_feed])
         time.sleep(60)
 
 


### PR DESCRIPTION
script will now launch witness node and cli wallet, unlock wallet, watch for missed blocks and switch between public keys, switch to emergency keys if all primary keys miss blocks twice, close and relaunch with --replay-blockchain if witness participation falls below 50% or witness node or script crashes.  Will close and relaunch with --resync-blockchain if three attempts at --replay-blockchain are unable to fix problem.  Requires lots of config.py parameters.  