### PR TITLE
Added Websocket(RPC) failover

### DIFF
--- a/grapheneapi/graphenews.py
+++ b/grapheneapi/graphenews.py
@@ -1,6 +1,7 @@
 import time
 import asyncio
 import ssl
+import logging
 from collections import OrderedDict
 from itertools import cycle
 
@@ -181,7 +182,6 @@ class GrapheneWebsocket(GrapheneWebsocketRPC):
                     coro = loop.create_connection(self.factory, self.host,
                                                   self.port, ssl=context)
                 else :
-
                     coro = loop.create_connection(self.factory, self.host,
                                                   self.port, ssl=self.ssl)
                 loop.run_until_complete(coro)
@@ -190,12 +190,12 @@ class GrapheneWebsocket(GrapheneWebsocketRPC):
                 break
 
             try:
-                print("Multiple witnesses configured, trying another witness.")
+                logging.info("Multiple witnesses configured, trying another witness.")
                 GrapheneWebsocketRPC.__init__(self, self.url_list, self.username, self.password)
                 self.ssl, self.host, self.port, self.resource, self.path, self.params = parseWsUrl(self.url)
                 self.connect()
             except NameError or AttributeError:
-                print("Just one witness configured, trying to re-connect in 10 seconds!")
+                logging.info("Just one witness configured, trying to re-connect in 10 seconds!")
                 time.sleep(10)
-        print("Good bye!")
+        logging.info("Good bye!")
         loop.close()

--- a/grapheneapi/graphenews.py
+++ b/grapheneapi/graphenews.py
@@ -184,21 +184,18 @@ class GrapheneWebsocket(GrapheneWebsocketRPC):
 
                     coro = loop.create_connection(self.factory, self.host,
                                                   self.port, ssl=self.ssl)
-
                 loop.run_until_complete(coro)
                 loop.run_forever()
             except KeyboardInterrupt:
                 break
 
-            print("Trying to re-connect in 10 seconds!")
-            time.sleep(10)
-
             try:
-                self.url = next(self.url_iterator)
-                print("Connecting to %s" % self.url)
+                print("Multiple witnesses configured, trying another witness.")
+                GrapheneWebsocketRPC.__init__(self, self.url_list, self.username, self.password)
+                self.ssl, self.host, self.port, self.resource, self.path, self.params = parseWsUrl(self.url)
                 self.connect()
-            except NameError:
-                print("Just one witness configured, reconnecting")
-
+            except NameError or AttributeError:
+                print("Just one witness configured, trying to re-connect in 10 seconds!")
+                time.sleep(10)
         print("Good bye!")
         loop.close()

--- a/grapheneapi/graphenewsrpc.py
+++ b/grapheneapi/graphenewsrpc.py
@@ -2,6 +2,7 @@ import threading
 from websocket import create_connection
 import json
 import time
+import logging
 import collections
 from itertools import cycle
 
@@ -43,16 +44,12 @@ class GrapheneWebsocketRPC(object):
             if not isinstance(self.url_iterator, collections.Iterable):
                 self.url_iterator = cycle(self.url_list)
             self.url = next(self.url_iterator)
-            for num in range(len(self.url_list)):
-                try:
-                    self.ws = create_connection(self.url)
-                    print("Connected to %s" % self.url)
-                    break
-                except ConnectionRefusedError as e:
-                    print("Can't connect to %s" % self.url)
-                    if num + 1 == len(self.url_list):
-                        raise ConnectionRefusedError
-                    self.url = next(self.url_iterator)
+            try:
+                self.ws = create_connection(self.url)
+                logging.info("Connected to %s" % self.url)
+            except ConnectionRefusedError:
+                logging.warning("Can't connect to %s" % self.url)
+                self.__init__(self.url_iterator, user, password)
         else:
             self.url = url
             self.ws = create_connection(self.url)


### PR DESCRIPTION
Added the possibility to provide GrapheneWebsocketRPC() and GrapheneWebsocket(GrapheneWebsocketRPC) with a list of witness urls instead of one.

Automatically switches over to the next node in the list when the connection with a full node is lost.