### PR TITLE
fix the type bug in returnTradeHistory method and make it work for BT…

### DIFF
--- a/grapheneexchange/exchange.py
+++ b/grapheneexchange/exchange.py
@@ -881,7 +881,7 @@ class GrapheneExchange(GrapheneClient) :
                 if f["op"]["account_id"] == self.myAccount["id"]:
                     if f["op"]["pays"]["asset_id"] == m["base"] :
                         data["type"]   = "buy"
-                        data["amount"] = f["op"]["receives"]["amount"] / 10 ** quote["precision"]
+                        data["amount"] = int(f["op"]["receives"]["amount"]) / 10 ** quote["precision"]
                     else :
                         data["type"]   = "sell"
                         data["amount"] = int(f["op"]["pays"]["amount"]) / 10 ** quote["precision"]  #here to add int() because the f["op"]["pays"]["amount"] is wrongly returned a string from self.ws.get_fill_order_history

--- a/grapheneexchange/exchange.py
+++ b/grapheneexchange/exchange.py
@@ -873,21 +873,20 @@ class GrapheneExchange(GrapheneClient) :
             filled = self.ws.get_fill_order_history(
                 m["quote"], m["base"], 2 * limit, api="history")
             trades = []
-            for f in filled[1::2] :  # every second entry "fills" the order
+            for f in filled:
                 data = {}
                 data["date"] = f["time"]
                 data["rate"] = self._get_price_filled(f, m)
                 quote = self._get_asset(m["quote"])
-                # base = self._get_asset(m["base"])
-                if f["op"]["pays"]["asset_id"] == m["base"] :
-                    data["type"]   = "buy"
-                    data["amount"] = f["op"]["receives"]["amount"] / 10 ** quote["precision"]
-                else :
-                    data["type"]   = "sell"
-                    data["amount"] = f["op"]["pays"]["amount"] / 10 ** quote["precision"]
-                data["total"]  = data["amount"] * data["rate"]
-                trades.append(data)
-
+                if f["op"]["account_id"] == self.myAccount["id"]:
+                    if f["op"]["pays"]["asset_id"] == m["base"] :
+                        data["type"]   = "buy"
+                        data["amount"] = f["op"]["receives"]["amount"] / 10 ** quote["precision"]
+                    else :
+                        data["type"]   = "sell"
+                        data["amount"] = int(f["op"]["pays"]["amount"]) / 10 ** quote["precision"]  #here to add int() because the f["op"]["pays"]["amount"] is wrongly returned a string from self.ws.get_fill_order_history
+                    data["total"]  = data["amount"] * data["rate"]
+                    trades.append(data)
             r.update({market : trades})
         return r
 


### PR DESCRIPTION
instead select every second entry "fills" the order, use account to select the right entries.

int(f["op"]["pays"]["amount"] to avoid str/int error, seems self.ws.get_fill_order_history return wrongly format data 

