### PR TITLE
Add "readwire" interface to *some* Graphene Types.

### DIFF
--- a/graphenebase/account.py
+++ b/graphenebase/account.py
@@ -277,6 +277,18 @@ class PublicKey(Address):
         """ Returns the raw public key (has length 33)"""
         return bytes(self._pk)
 
+    @staticmethod
+    def _readwire(d, prefix="GPH"):
+        _pk = hexlify(d[:33]).decode('ascii')
+
+        k = PublicKey.__new__(PublicKey)
+        k.prefix = prefix
+        k._pk = Base58(_pk, prefix)
+        k.address = Address(pubkey=_pk, prefix=prefix)
+        k.pubkey = k._pk
+
+        return k, d[33:]
+
 
 class PrivateKey(PublicKey):
     """ Derives the compressed and uncompressed public keys and


### PR DESCRIPTION
This is useful when you want to *read* the serialized wire protocol back into objects-in-memory. Although this is rarely used on the client side of graphene networks, at least one particular use case (BitShares blind transfers) exists.

To clarify: this is __bytes__ method in reverse.

The `_readwire` interface and method signature are pretty horrid, so some redesign might be required.