### PR TITLE
Add get_blind_private method to BrainKey.

### DIFF
--- a/graphenebase/account.py
+++ b/graphenebase/account.py
@@ -99,6 +99,12 @@ class BrainKey(object):
         s = hashlib.sha256(hashlib.sha512(a).digest()).digest()
         return PrivateKey(hexlify(s).decode('ascii'))
 
+    def get_blind_private(self):
+        """ Derive private key from the brain key (and no sequence number)
+        """
+        a = _bytes(self.brainkey)
+        return PrivateKey(hashlib.sha256(a).hexdigest())
+
     def get_public(self):
         return self.get_private().pubkey
 

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -218,6 +218,12 @@ class Testcases(unittest.TestCase):
             p = b.next_sequence().get_private()
             self.assertEqual(str(p), i)
 
+    def test_BrainKey_blind(self):
+        b = BrainKey("MATZO COLORER BICORN KASBEKE FAERIE LOCHIA GOMUTI SOVKHOZ Y GERMAL AUNTIE PERFUMY TIME FEATURE GANGAN CELEMIN")
+        key = "5JmdAQbRpV94LDVb2igq6YR5MVj1NVaJxBWpHP9Y6LspmMobbv5"
+        p = b.get_blind_private()
+        self.assertEqual(str(p), key)
+
     def test_PasswordKey(self):
         a = ["Aang7foN3oz1Ungai2qua5toh3map8ladei1eem2ohsh2shuo8aeji9Thoseo7ah",
              "iep1Mees9eghiifahwei5iidi0Sazae9aigaeT7itho3quoo2dah5zuvobaelau5",


### PR DESCRIPTION
This is the same as `get_private` method, but without any sequence number. It's used for generating private keys for Blind accounts on BitShares network.