### PR TITLE
Restore tweakaddPubkey method and related unit tests.

### DIFF
--- a/graphenebase/account.py
+++ b/graphenebase/account.py
@@ -286,11 +286,13 @@ class PublicKey(Prefix):
             string[1:], curve=ecdsa.SECP256k1).pubkey.point
 
     def child(self, offset256):
+        """ Derive new public key from this key and a sha256 "offset" """
         a = bytes(self) + offset256
         s = hashlib.sha256(a).digest()
         return self.add(s)
 
     def add(self, digest256):
+        """ Derive new public key from this key and a sha256 "digest" """
         from .ecdsa import tweakaddPubkey
         return tweakaddPubkey(self, digest256)
 

--- a/graphenebase/ecdsa.py
+++ b/graphenebase/ecdsa.py
@@ -308,18 +308,17 @@ def verify_message(message, signature, hashfn=hashlib.sha256):
 #     x_str = ecdsa.util.number_to_string(x, order)
 #     return _bytes(chr(2 + (y & 1))) + x_str   # pragma: no cover
 #
-#
-# def tweakaddPubkey(pk, digest256, SECP256K1_MODULE=SECP256K1_MODULE):
-#     if SECP256K1_MODULE == "secp256k1":
-#         tmp_key = secp256k1.PublicKey(pubkey=bytes(pk), raw=True)
-#         new_key = tmp_key.tweak_add(digest256)  # <-- add
-#         raw_key = hexlify(new_key.serialize()).decode('ascii')
-#     else:
-#         raise Exception("Must have secp256k1 for `tweak_add`")
-#         raw_key = ecmult(pk, 1, digest256, SECP256K1_MODULE)
-#
-#     return PublicKey(raw_key, prefix=pk.prefix)
-#
+
+def tweakaddPubkey(pk, digest256, SECP256K1_MODULE=SECP256K1_MODULE):
+    if SECP256K1_MODULE == "secp256k1":
+        tmp_key = secp256k1.PublicKey(pubkey=bytes(pk), raw=True)
+        new_key = tmp_key.tweak_add(digest256)  # <-- add
+        raw_key = hexlify(new_key.serialize()).decode('ascii')
+    else:
+        raise Exception("Must have secp256k1 for `tweak_add`")
+        # raw_key = ecmult(pk, 1, digest256, SECP256K1_MODULE)
+    return PublicKey(raw_key, prefix=pk.prefix)
+
 #
 # def tweakmulPubkey(pk, digest256, SECP256K1_MODULE=SECP256K1_MODULE):
 #     if SECP256K1_MODULE == "secp256k1":

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,7 @@
 autobahn>=0.14
 pycrypto==2.6.1
 scrypt>=0.7.1
+secp256k1
 pytest
 coverage
 mock

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -312,7 +312,6 @@ class Testcases(unittest.TestCase):
             b"\x90d5\xf6\xf9\xceo=NL\xf8\xd3\xd0\xdd\xce \x9a\x83'w8\xff\xdc~\xaec\x08\xf4\xed)c\xdf",
             b'\r\xa8tl\xf1:a\x89\xa2\x81\x96\\X\x0fBA]\x86\xe9l#*\x89%\xea\x152T\xbb\x87\x9f`'
         ])
-        """
         self.assertEqual(
             repr(pub.child(b"foobar")),
             "022a42ae1e9af8f84544c9a1970308c31f864dfb4f5998c45ef76e11d307cc77d5"
@@ -321,7 +320,6 @@ class Testcases(unittest.TestCase):
             repr(pub.add(hashlib.sha256(b"Foobar").digest())),
             "0354a2c06c398990c52933df0c93b9904a4b23b0e2d524a3b0075c72adaa4e459e"
         )
-        """
 
     def test_BrainKey_sequence(self):
         b = BrainKey("COLORER BICORN KASBEKE FAERIE LOCHIA GOMUTI SOVKHOZ Y GERMAL AUNTIE PERFUMY TIME FEATURE GANGAN CELEMIN MATZO")


### PR DESCRIPTION
I've noticed it's commented out. 

(I don't remember if `tweakmulPubkey` is actually used anywhere, so I've left it out for now.)