### PR TITLE
Add zero padding to derived privkeys.

### DIFF
--- a/graphenebase/account.py
+++ b/graphenebase/account.py
@@ -452,6 +452,8 @@ class PrivateKey(Prefix):
         order = ecdsa.SECP256k1.order
         secexp = (seed + z) % order
         secret = "%0x" % secexp
+        if len(secret) < 64: # left-pad with zeroes
+            secret = ("0" * (64-len(secret))) + secret
         return PrivateKey(secret, prefix=self.pubkey.prefix)
 
     def __format__(self, _format):

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -771,6 +771,16 @@ class Testcases(unittest.TestCase):
             repr(p2), "2dc7cb99933132e25b37710f9ea806228b04a583da11a137ef97fd42c0007390"
         )
 
+    def test_derive_child(self):
+       # NOTE: this key + offset pair is particularly nasty, as
+       # the resulting derived value is less then 64 bytes long.
+       # Thus, this test also tests for proper padding.
+       p = PrivateKey("5K6hMUtQB2xwjuz3SRR6uM5HNERWgBqcK7gPPZ31XtAyBNoATZd")
+       p2 = p.child(b'\xaf\x8f: \xf6T?V\x0bM\xd8\x16 \xfd\xde\xe9\xb9\xac\x03\r\xba\xb2\x8d\x868-\xc2\x90\x80\xe8\x1b\xce')
+       self.assertEqual(
+           repr(p2), "0c5fae344a513a4cfab312b24c08df2b2d6afa25c0ead0d3d1d0d3e76794109b"
+       )
+
     def test_init_wrong_format(self):
         with self.assertRaises(NotImplementedError):
             PrivateKey("KJWcdkhL3w4RkVPcZMdJsjos22yB5cSkPExerktvKnRNZR5gx1S")


### PR DESCRIPTION
I've randomly encounted a privkey + offset combo that provide a 63-byte secret value (instead of expected 64). Looking at the code, there's nothing to guarantee secp values will be large enough, so some padding is necessary.