### PR TITLE
Factor out common sqlite operations into a separate class.

### DIFF
--- a/graphenestorage/__init__.py
+++ b/graphenestorage/__init__.py
@@ -8,7 +8,7 @@ from .base import (
     SqlitePlainKeyStore,
     SqliteEncryptedKeyStore,
 )
-from .sqlite import SQLiteFile
+from .sqlite import SQLiteFile, SQLiteCommon
 
 __all__ = ["interfaces", "masterpassword", "base", "sqlite", "ram"]
 


### PR DESCRIPTION
Each time sqlite-related fetch/execute is performed, the code similar to
```
connection = sqlite3.connect(self.sqlite_file)
cursor = connection.cursor()
cursor.execute(*query)
```
is executed.

It would be beneficial to factor those out, to avoid some code duplication, but more importantly, to allow one to redefine those methods (without messing around the actual `keys()` or `items()` functions).

I do, in fact, override those methods in the python-qt wallet implementation of python-graphenelib, to provide additional safeguards (and thread-safe locking), as sqlite on some platforms is compiled in non-thread-safe mode.

Note on implementation: this adds yet another class to the sqlite-storage stack. Arguably, SQLiteFile class could've handled this, but I've found it's nice to separate the actual operations and the "find/create/set-filename/handle userdir" functionality, that SQLiteFile is providing. This way, I have a choice to override both, one of them, neither, etc.