### PR TITLE
Keep block identifier

### DIFF
--- a/graphenecommon/block.py
+++ b/graphenecommon/block.py
@@ -41,12 +41,15 @@ class Block(BlockchainObject, AbstractBlockchainInstanceProvider):
         """ Even though blocks never change, you freshly obtain its contents
             from an API with this method
         """
+        identifier = self.identifier
         block = self.blockchain.rpc.get_block(self.identifier)
         if not block:
             raise BlockDoesNotExistsException
         super(Block, self).__init__(
             block, blockchain_instance=self.blockchain, use_cache=self._use_cache
         )
+        # block does not contain an id and thus identifier gets overwritten
+        self.identifier = identifier
 
     def time(self):
         """ Return a datatime instance for the timestamp of this block


### PR DESCRIPTION
block does not contain an id and thus identifier gets overwritten