### PR TITLE
Fix RPC method calling in aio version

### DIFF
--- a/grapheneapi/api.py
+++ b/grapheneapi/api.py
@@ -162,9 +162,15 @@ class Api:
         pass
 
     def __getattr__(self, name):
+        """ Proxies RPC calls to actual Websocket or Http instance.
+
+            Connection-related errors catched here and handled.
+        """
+
         def func(*args, **kwargs):
             while True:
                 try:
+                    # RPC method called on actual Websocket or Http class
                     func = self.connection.__getattr__(name)
                     r = func(*args, **kwargs)
                     self.reset_counter()


### PR DESCRIPTION
__getattr__() in grapheneapi.aio.Api wasn't defined, so it used regular
__getattr__(), which didn't contains `await func()` call, so it just
returned a coroutine without actually calling it, so all exception
handling didn't worked here. Thus, connection-related errors (broken
connection) weren't handled.