### PR TITLE
Avoid double instantiation of operations

### DIFF
--- a/graphenecommon/aio/transactionbuilder.py
+++ b/graphenecommon/aio/transactionbuilder.py
@@ -307,17 +307,12 @@ class TransactionBuilder(SyncTransactionBuilder):
         elif "blockchain" in self:
             self.operations.default_prefix = self["blockchain"]["prefix"]
 
-        try:
-            signedtx = self.signed_transaction_class(**await self.json())
-        except Exception:
-            raise ValueError("Invalid TransactionBuilder Format")
-
         if not any(self.wifs):
             raise MissingKeyError
 
-        signedtx.sign(self.wifs, chain=self.blockchain.rpc.chain_params)
-        self["signatures"].extend(signedtx.json().get("signatures"))
-        return signedtx
+        self.tx.sign(self.wifs, chain=self.blockchain.rpc.chain_params)
+        self["signatures"].extend(self.tx.json().get("signatures"))
+        return self.tx
 
     async def verify_authority(self):
         """ Verify the authority of the signed transaction

--- a/graphenecommon/transactionbuilder.py
+++ b/graphenecommon/transactionbuilder.py
@@ -467,17 +467,12 @@ class TransactionBuilder(dict, AbstractBlockchainInstanceProvider):
         elif "blockchain" in self:
             self.operations.default_prefix = self["blockchain"]["prefix"]
 
-        try:
-            signedtx = self.signed_transaction_class(**self.json())
-        except Exception:
-            raise ValueError("Invalid TransactionBuilder Format")
-
         if not any(self.wifs):
             raise MissingKeyError
 
-        signedtx.sign(self.wifs, chain=self.blockchain.rpc.chain_params)
-        self["signatures"].extend(signedtx.json().get("signatures"))
-        return signedtx
+        self.tx.sign(self.wifs, chain=self.blockchain.rpc.chain_params)
+        self["signatures"].extend(self.tx.json().get("signatures"))
+        return self.tx
 
     def verify_authority(self):
         """ Verify the authority of the signed transaction


### PR DESCRIPTION
Problem: any high-level method as bitshares.transfer() instantiates
op = operations.Transfer(), then self.json() inside TransactionBuilder
makes OrderedDict to dict, and then Signed_Transaction class have to
reconstruct all operations via kwargs["operations"] = Array([opklass(a)
for a in ops]). This way breaks possible use of Variant type encoding
(may be used by other chains).