### PR TITLE
Always sign() proposal trx before broadcasting

### DIFF
--- a/graphenecommon/aio/transactionbuilder.py
+++ b/graphenecommon/aio/transactionbuilder.py
@@ -35,6 +35,7 @@ class ProposalBuilder(SyncProposalBuilder):
     async def broadcast(self):
         assert self.parent, "No parent transaction provided!"
         self.parent._set_require_reconstruction()
+        await self.parent.sign()
         return await self.parent.broadcast()
 
     async def json(self):

--- a/graphenecommon/transactionbuilder.py
+++ b/graphenecommon/transactionbuilder.py
@@ -84,6 +84,7 @@ class ProposalBuilder(AbstractBlockchainInstanceProvider):
     def broadcast(self):
         assert self.parent, "No parent transaction provided!"
         self.parent._set_require_reconstruction()
+        self.parent.sign()
         return self.parent.broadcast()
 
     def get_parent(self):


### PR DESCRIPTION
When calling broadcast() on proposal, it proxied to self.parent, which
performing self.sign() only if not signed already. Proposal uses main
TransactionBuilder instance by default, which may contain signature from
previously broadcasted trx, thus failing proposal broadcast with
"Missing Active Authority".