### PR TITLE
Set a timeout when connecting to websocket server

### DIFF
--- a/grapheneapi/websocket.py
+++ b/grapheneapi/websocket.py
@@ -33,6 +33,7 @@ class Websocket(Rpc):
             if self.proxy_user
             else None,
             proxy_type=self.proxy_type,
+            timeout=30
         )
 
         if self.user and self.password:


### PR DESCRIPTION
See https://github.com/Codaone/DEXBot/issues/447.

The client may occasionally hang on `recv()` when fetching data from an API node, this can be simulated using the iptables rule `iptables -A INPUT -s x.x.x.x -p tcp --sport xxx -j DROP`. Setting a timeout can fix it.

The reason why it may hang on `recv()` is still unknown, maybe it's an OS bug.