### PR TITLE
fix: store items duplicate check

### DIFF
--- a/graphenecommon/blockchainobject.py
+++ b/graphenecommon/blockchainobject.py
@@ -38,11 +38,11 @@ class Caching:
         key = key or self.__class__.__name__
         if key in self._cache:
             # check for duplicates. race condition when loading might cause that store_items is called twice with same list
+            toadd = []
             for x in list(self):
-                toadd = []
                 if x not in self._cache[key]:
                     toadd.append(x)
-                self._cache[key].extend(toadd)
+            self._cache[key].extend(toadd)
         else:
             self._cache[key] = list(self)
         self._fetched = True

--- a/graphenecommon/blockchainobject.py
+++ b/graphenecommon/blockchainobject.py
@@ -37,7 +37,12 @@ class Caching:
     def _store_items(self, key=None):
         key = key or self.__class__.__name__
         if key in self._cache:
-            self._cache[key].extend(list(self))
+            # check for duplicates. race condition when loading might cause that store_items is called twice with same list
+            for x in list(self):
+                toadd = []
+                if x not in self._cache[key]:
+                    toadd.append(x)
+                self._cache[key].extend(toadd)
         else:
             self._cache[key] = list(self)
         self._fetched = True


### PR DESCRIPTION
On some race conditions, a blockchain object list may call twice store_items with the same list loaded, thus creating duplicates in the cache. 

This fix adds a duplicate check to the cache